### PR TITLE
Mirin Template v3.0.0

### DIFF
--- a/template/ease.xml
+++ b/template/ease.xml
@@ -117,13 +117,13 @@
 		end
 	end
 	function inExpo(t) return 1000 ^ (t - 1) - 0.001 end
-	function outExpo(t) return 0.999 - 1000 ^ -t end
+	function outExpo(t) return 1.001 - 1000 ^ -t end
 	function inOutExpo(t)
 		t = t * 2
 		if t < 1 then
 			return 0.5 * 1000 ^ (t - 1) - 0.0005
 		else
-			return 0.9995 - 0.5 * 1000 ^ (1 - t)
+			return 1.0005 - 0.5 * 1000 ^ (1 - t)
 		end
 	end
 	function inCirc(t) return 1 - sqrt(1 - t * t) end

--- a/template/ease.xml
+++ b/template/ease.xml
@@ -12,11 +12,17 @@
 	end
 	
 	-- make a function cache its results from previous calls
-	local function fncache(func)
+	local function fncache(func, default)
 		local cache = {}
 		return function(arg)
+			if arg == nil then arg = default end
 			cache[arg] = cache[arg] or func(arg)
 			return cache[arg]
+		end
+	end
+	local function uncurry2(func)
+		return function(a, b)
+			func(a)(b)
 		end
 	end
 	
@@ -138,36 +144,49 @@
 		end
 	end
 	
-	function inElastic(t)
-		t = t - 1
-		return -(pow(2, 10 * t) * sin((t - 0.075) * (2 * pi) / 0.3))
-	end
-	function outElastic(t)
-		return pow(2, -10 * t) * sin((t - 0.075) * (2 * pi) / 0.3) + 1
-	end
-	function inOutElastic(t)
-		t = t * 2 - 1
-		if t < 0 then
-			return -0.5 * pow(2, 10 * t) * sin((t - 0.1125) * 2 * pi / 0.45)
-		else
-			return pow(2, -10 * t) * sin((t - 0.1125) * 2 * pi / 0.45) * 0.5 + 1
+	inElastic = function(a)
+		local inner = function(p)
+			return function(t)
+				t = t - 1
+				return -(a * pow(2, 10 * t) * sin(t - p / (2 * pi) * asin(1/a)) * (2 * pi) / p)
+			end
 		end
+		return fncache(inner, 0.3)
 	end
+	inElastic = uncurry2(fncache(inElastic, 1))
+
+	function outElastic(a)
+		local inner = function(p)
+			return function(t)
+				return a * pow(2, 10 * t) * sin(t - p / (2 * pi) * asin(1/a)) * (2 * pi) / p + 1
+			end
+		end
+		return fncache(inner, 0.3)
+	end
+	outElastic = uncurry2(fncache(outElastic, 1))
+
+	function inOutElastic(a)
+		local inner = function(p)
+			local in1 = inElastic(a, p)
+			local out1 = outElastic(a, p)
+			return function(t) return t < 0.5 and in1(t * 2) * 0.5 or out1(t * 2 - 1) * 0.5 + 0.5 end
+		end
+		return fncache(inner, 0.3)
+	end
+	inOutElastic = uncurry2(fncache(inOutElastic, 1))
 	
-	function inBack(t) return t * t * (2.70158 * t - 1.70158) end
-	function outBack(t)
-		t = t - 1
-		return (t * t * (2.70158 * t + 1.70158)) + 1
+	function inBack(a) return function(t) return t * t * (a * t + t - a) end end
+	inBack = fncache(inBack, 1.70158)
+
+	function outBack(a) return function(t) t = t - 1 return t * t * (a * t + a) + 1 end end
+	outBack = fncache(outBack, 1.70158)
+
+	function inOutBack(s)
+		local in1 = inBack(s)
+		local out1 = outBack(s)
+		return function(t) return t < 0.5 and in1(t * 2) * 0.5 or out1(t * 2 - 1) * 0.5 + 0.5 end
 	end
-	function inOutBack(t)
-		t = t * 2
-		if t < 1 then
-			return 0.5 * (t * t * (3.5864016 * t - 2.5864016))
-		else
-			t = t - 2
-			return 0.5 * (t * t * (3.5864016 * t + 2.5864016) + 2)
-		end
-	end
+	inOutBack = fncache(inOutBack, 1.70158)
 	
 	function outBounce(t)
 		if t < 1 / 2.75 then

--- a/template/ease.xml
+++ b/template/ease.xml
@@ -1,43 +1,53 @@
 <Template Condition = "(function() --ease.xml
 	xero()
 	
-	-- make a self-filling table based on a generator function
-	local function cache(func)
-		return setmetatable({}, {
-			__index = function(self, k)
-				self[k] = func(k)
-				return self[k]
-			end
-		})
-	end
-	
-	-- make a function cache its results from previous calls
-	local function fncache(func, default)
-		local cache = {}
-		return function(arg)
-			if arg == nil then arg = default end
-			cache[arg] = cache[arg] or func(arg)
-			return cache[arg]
-		end
-	end
-	local function uncurry2(func)
-		return function(a, b)
-			func(a)(b)
-		end
-	end
-	
 	local sqrt = math.sqrt
 	local sin = math.sin
+	local asin = math.asin
 	local cos = math.cos
 	local pow = math.pow
 	local exp = math.exp
 	local pi = math.pi
 	local abs = math.abs
 	
-	function flip(fn)
-		return function(x) return 1 - fn(x) end
+	flip = setmetatable({}, {
+		__call = function(self, fn)
+			self[fn] = self[fn] or function(x) return 1 - fn(x) end
+			return self[fn]
+		end
+	})
+
+	function with1param(fn, defaultparam1)
+		local function params(param1)
+			return function(x)
+				return fn(x, param1)
+			end
+		end
+		local default = params(defaultparam1)
+		return setmetatable({
+			params = params
+		}, {
+			__call = function(self, x)
+				return default(x)
+			end
+		})
 	end
-	flip = fncache(flip)
+
+	function with2params(fn, defaultparam1, defaultparam2)
+		local function params(param1, param2)
+			return function(x)
+				return fn(x, param1, param2)
+			end
+		end
+		local default = params(defaultparam1, defaultparam2)
+		return setmetatable({
+			params = params
+		}, {
+			__call = function(self, x)
+				return default(x)
+			end
+		})
+	end
 	
 	function bounce(t) return 4 * t * (1 - t) end
 	function tri(t) return 1 - abs(2 * t - 1) end
@@ -49,36 +59,30 @@
 	function spike(t) return exp(-10 * abs(2 * t - 1)) end
 	function inverse(t) return t * t * (1 - t) * (1 - t) / (0.5 - t) end
 	
-	popElastic = cache(function(damp)
-		return cache(function(count)
-			return function(t)
-				return (1000 ^ -(t ^ damp) - 0.001) * sin(count * pi * t)
-			end
-		end)
-	end)
-	tapElastic = cache(function(damp)
-		return cache(function(count)
-			return function(t)
-				return (1000 ^ -((1 - t) ^ damp) - 0.001) * sin(count * pi * (1 - t))
-			end
-		end)
-	end)
-	pulseElastic = cache(function(damp)
-		return cache(function(count)
-			local tap_e = tapElastic[damp][count]
-			local pop_e = popElastic[damp][count]
-			return function(t)
-				return t > .5 and -pop_e(t * 2 - 1) or tap_e(t * 2)
-			end
-		end)
-	end)
-	
-	impulse = cache(function(damp)
-		return function(t)
-			t = t ^ damp
-			return t * (1000 ^ -t - 0.001) * 18.6
+	local function popElasticInternal(t, damp, count)
+		return (1000 ^ -(t ^ damp) - 0.001) * sin(count * pi * t)
+	end
+
+	local function tapElasticInternal(t, damp, count)
+		return (1000 ^ -((1 - t) ^ damp) - 0.001) * sin(count * pi * (1 - t))
+	end
+
+	local function pulseElasticInternal(t, damp, count)
+		if t < .5 then
+			return tapElasticInternal(t * 2, damp, count)
+		else
+			return -popElasticInternal(t * 2 - 1, damp, count)
 		end
-	end)
+	end
+
+	popElastic = with2params(popElasticInternal, 1.4, 6)
+	tapElastic = with2params(tapElasticInternal, 1.4, 6)
+	pulseElastic = with2params(pulseElasticInternal, 1.4, 6)
+	
+	impulse = with1param(function(t, damp)
+		t = t ^ damp
+		return t * (1000 ^ -t - 0.001) * 18.6
+	end, 0.9)
 	
 	function instant() return 1 end
 	function linear(t) return t end
@@ -144,50 +148,6 @@
 		end
 	end
 	
-	inElastic = function(a)
-		local inner = function(p)
-			return function(t)
-				t = t - 1
-				return -(a * pow(2, 10 * t) * sin(t - p / (2 * pi) * asin(1/a)) * (2 * pi) / p)
-			end
-		end
-		return fncache(inner, 0.3)
-	end
-	inElastic = uncurry2(fncache(inElastic, 1))
-
-	function outElastic(a)
-		local inner = function(p)
-			return function(t)
-				return a * pow(2, 10 * t) * sin(t - p / (2 * pi) * asin(1/a)) * (2 * pi) / p + 1
-			end
-		end
-		return fncache(inner, 0.3)
-	end
-	outElastic = uncurry2(fncache(outElastic, 1))
-
-	function inOutElastic(a)
-		local inner = function(p)
-			local in1 = inElastic(a, p)
-			local out1 = outElastic(a, p)
-			return function(t) return t < 0.5 and in1(t * 2) * 0.5 or out1(t * 2 - 1) * 0.5 + 0.5 end
-		end
-		return fncache(inner, 0.3)
-	end
-	inOutElastic = uncurry2(fncache(inOutElastic, 1))
-	
-	function inBack(a) return function(t) return t * t * (a * t + t - a) end end
-	inBack = fncache(inBack, 1.70158)
-
-	function outBack(a) return function(t) t = t - 1 return t * t * (a * t + a) + 1 end end
-	outBack = fncache(outBack, 1.70158)
-
-	function inOutBack(s)
-		local in1 = inBack(s)
-		local out1 = outBack(s)
-		return function(t) return t < 0.5 and in1(t * 2) * 0.5 or out1(t * 2 - 1) * 0.5 + 0.5 end
-	end
-	inOutBack = fncache(inOutBack, 1.70158)
-	
 	function outBounce(t)
 		if t < 1 / 2.75 then
 			return 7.5625 * t * t
@@ -222,5 +182,33 @@
 	function inOutSine(x)
 		return 0.5 - 0.5 * cos(x * pi)
 	end
+
+	function outElasticInternal(t, a, p)
+		return a * pow(2, -10 * t) * sin((t - p / (2 * pi) * asin(1/a)) * 2 * pi / p) + 1
+	end
+	local function inElasticInternal(t, a, p)
+		return 1 - outElasticInternal(1 - t, a, p)
+	end
+	function inOutElasticInternal(t, a, p)
+		return t < 0.5
+			and  0.5 * inElasticInternal(t * 2, a, p)
+			or  0.5 + 0.5 * outElasticInternal(t * 2 - 1, a, p)
+	end
+
+	inElastic = with2params(inElasticInternal, 1, 0.3)
+	outElastic = with2params(outElasticInternal, 1, 0.3)
+	inOutElastic = with2params(inOutElasticInternal, 1, 0.3)
+
+	function inBackInternal(t, a) return t * t * (a * t + t - a) end
+	function outBackInternal(t, a) t = t - 1 return t * t * ((a + 1) * t + a) + 1 end
+	function inOutBackInternal(t, a)
+		return t < 0.5
+			and  0.5 * inBackInternal(t * 2, a)
+			or  0.5 + 0.5 * outBackInternal(t * 2 - 1, a)
+	end
+	
+	inBack = with1param(inBackInternal, 1.70158)
+	outBack = with1param(outBackInternal, 1.70158)
+	inOutBack = with1param(inOutBackInternal, 1.70158)
 	
 end)()"/>

--- a/template/std.xml
+++ b/template/std.xml
@@ -169,14 +169,7 @@
 	end
 	
 	local stringbuilder_mt =  {
-		__index = {
-			build = table.concat,
-			sep = function(self, sep)
-				if self[1] then
-					self(sep)
-				end
-			end,
-		},
+		__index = {build = table.concat},
 		__tostring = table.concat,
 		__call = function(self, a)
 			table.insert(self, tostring(a))

--- a/template/template.xml
+++ b/template/template.xml
@@ -97,7 +97,6 @@
 	
 	-- mod aliases, or ease vars
 	local aliases = {}
-	local reverse_aliases = {}
 	
 	-- alias a mod
 	function alias(self, depth, name)
@@ -109,30 +108,15 @@
 		end
 		local a, b = self[1], self[2]
 		if type(a) ~= 'string' then
-			screen_error('unexpected argument 1', depth, name)
+			screen_error('argument 1 should be a string', depth, name)
 			return alias
 		end
 		if type(b) ~= 'string' then
-			screen_error('unexpected argument 2', depth, name)
+			screen_error('argument 2 should be a string', depth, name)
 			return alias
 		end
 		a, b = string.lower(a), string.lower(b)
-		-- TODO make alias logic clearer
-		local collection = {a}
-		while aliases[b] do
-			if reverse_aliases[b] then
-				for _, item in ipairs(reverse_aliases[b]) do
-					table.insert(collection, item)
-				end
-				reverse_aliases[b] = nil
-			end
-			b = aliases[b]
-		end
-		reverse_aliases[b] = reverse_aliases[b] or {}
-		for _, name in ipairs(collection) do
-			aliases[name] = b
-			table.insert(reverse_aliases[b], name)
-		end
+		aliases[a] = b
 		return alias
 	end
 	
@@ -144,6 +128,11 @@
 	-- eases are loaded after the template, so this needs to be declared early
 	local function instant()
 		return 1
+	end
+	
+	local touched_mods = {}
+	for pn = 1, max_pn do
+		touched_mods[pn] = {}
 	end
 	
 	-- the table of default mod values
@@ -172,8 +161,11 @@
 				return setdefault
 			end
 			default_mods[self[i + 1]] = self[i]
-			add ({0, 0, instant, 0, self[i + 1]}, depth, name)
+			for pn = 1, max_pn do
+				touched_mods[pn][self[i + 1]] = true
+			end
 		end
+		return setdefault
 	end
 	
 	-- the previously set value of a mod
@@ -250,6 +242,13 @@
 		-- update prev_mods table
 		if not self.transient then
 			for _, pn in ipairs(type(plr) == 'table' and plr or {plr}) do
+				if self.reset then
+					for mod, percent in pairs(prev_mods[pn]) do
+						if not self.exclude[mod] then
+							prev_mods[pn][mod] = default_mods[mod]
+						end
+					end
+				end
 				for n = 5, self.n, 2 do
 					if self.relative then
 						prev_mods[pn][self[n]] = prev_mods[pn][self[n]] + self[n - 1]
@@ -294,12 +293,13 @@
 		self.reset = true
 		self.exclude = self.exclude or {}
 		if type(self.exclude) == 'string' then
-			self.exclude == {self.exclude}
+			self.exclude = {self.exclude}
 		end
 		for _, v in ipairs(self.exclude) do
 			self.exclude[v] = true
 		end
 		ease(self, depth, name)
+		return reset
 	end
 	
 	-- the table of scheduled functions and perframes
@@ -418,10 +418,8 @@
 		end
 		local i = 1
 		local inputs = {}
-		local reverse_in = {}
 		while type(self[i]) == 'string' do
 			table.insert(inputs, self[i])
-			add({0, 0, instant, 0, self[i]}, depth, name)
 			i = i + 1
 		end
 		if i == 1 then
@@ -716,7 +714,7 @@
 		'zoomx', 'zoomy',
 		defer = true,
 	}
-	setdefault {100, 'zoom', 100, 'zoomx', 100, 'zoomy'}
+	setdefault {100, 'zoom', 100, 'zoomx', 100, 'zoomy', 100, 'zoomz'}
 	
 	-- movex
 	for _, a in ipairs {'x', 'y', 'z'} do
@@ -761,7 +759,9 @@
 	for pn = 1, max_pn do
 		mods[pn] = setmetatable({}, mods_mt[pn])
 	end
-
+	
+	local last_seen_awake = {}
+	
 	local poptions = {}
 	local poptions_mt = {}
 	local poptions_logging_target
@@ -922,6 +922,13 @@
 		
 		for pn = 1, max_pn do
 			if P[pn] and P[pn]:IsAwake() then
+				if not last_seen_awake[pn] then
+					last_seen_awake[pn] = true
+					for mod, percent in pairs(touched_mods[pn]) do
+						mods[pn][mod] = mods[pn][mod] + 0
+						touched_mods[pn][mod] = nil
+					end
+				end
 				mod_buffer = stringbuilder()
 				seen = seen + 1
 				for k in pairs(mods[pn]) do
@@ -944,6 +951,12 @@
 				end
 				if mod_buffer[1] then
 					apply_modifiers(mod_buffer:build(','), pn)
+				end
+			else
+				last_seen_awake[pn] = false
+				for mod, percent in pairs(mods[pn]) do
+					mods[pn][mod] = nil
+					touched_mods[pn][mod] = true
 				end
 			end
 		end

--- a/template/template.xml
+++ b/template/template.xml
@@ -431,7 +431,7 @@
 			i = i + 1
 		end
 		if i == 1 then
-			screen_error('inputs to node expected', depth, name)
+			screen_error('the first argument needs to be the mod name', depth, name)
 		end
 		local fn = self[i]
 		if type(fn) ~= 'function' then
@@ -439,7 +439,10 @@
 		end
 		i = i + 1
 		local out = {}
-		while type(self[i]) == 'string' do
+		while self[i] do
+			if type(self[i]) ~= 'string' then
+				screen_error('unexpected argument '..tostring(self[i])..', expected a string', depth, name)
+			end
 			table.insert(out, self[i])
 			i = i + 1
 		end

--- a/template/template.xml
+++ b/template/template.xml
@@ -754,7 +754,15 @@
 		'zoomx', 'zoomy',
 		defer = true,
 	}
-	setdefault {100, 'zoom', 100, 'zoomx', 100, 'zoomy', 100, 'zoomz'}
+
+	setdefault {
+		100, 'zoom',
+		100, 'zoomx',
+		100, 'zoomy',
+		100, 'zoomz',
+	}
+
+	setdefault {400, 'grain'}
 
 	-- movex
 	for _, a in ipairs {'x', 'y', 'z'} do

--- a/template/template.xml
+++ b/template/template.xml
@@ -324,8 +324,8 @@
 
 		-- new string syntax, like `func {0, 1, outExpo, scx*0.5, scx, 'P1:x'}`
 		for i = 1, #self do
-			if type(self[i]) == string then
-				self[i] = loadstring('return function(p) ' .. self[i].. '(p) end')()
+			if type(self[i]) == 'string' then
+				self[i] = xero(loadstring('return function(p) ' .. self[i].. '(p) end'))()
 				break
 			end
 		end
@@ -471,7 +471,6 @@
 	local targets = {}
 	mod_buffer = stringbuilder()
 
-
 	function touch_mod(mod, pn)
 		-- run metatables
 		if pn then
@@ -483,20 +482,21 @@
 		end
 	end
 
-	function touch_all_mods()
+	function touch_all_mods(pn)
 		for mod in pairs(default_mods) do
 			touch_mod(mod)
 		end
-		for pn = 1, max_pn do
+		if pn then
 			for mod in pairs(targets[pn]) do
 				touch_mod(mod, pn)
 			end
+		else
+			for pn = 1, 8 do
+				for mod in pairs(targets[pn]) do
+					touch_mod(mod, pn)
+				end
+			end
 		end
-	end
-
-	function launchattack(start_time, len, mods, pn)
-		GAMESTATE:LaunchAttack(start_time, len, mods, pn)
-		func{start_time, touch_all_mods}
 	end
 
 	local function compile_nodes()
@@ -951,7 +951,7 @@
 				e[3](beat, poptions)
 			else
 				if e.mods then
-					for mod, _ in e.mods[pn] do
+					for mod, _ in pairs(e.mods[pn]) do
 						touch_mod(mod)
 					end
 				end

--- a/template/template.xml
+++ b/template/template.xml
@@ -322,6 +322,14 @@
 			end
 		end
 
+		-- new string syntax, like `func {0, 1, outExpo, scx*0.5, scx, 'P1:x'}`
+		for i = 1, #self do
+			if type(self[i]) == string then
+				self[i] = loadstring('return function(p) ' .. self[i].. '(p) end')()
+				break
+			end
+		end
+
 		local can_use_poptions = false
 		local a, b, c, d, e, f = self[1], self[2], self[3], self[4], self[5], self[6]
 		-- function ease, type 3

--- a/template/template.xml
+++ b/template/template.xml
@@ -740,6 +740,19 @@
 		resolve_aliases()
 		compile_nodes()
 
+		-- disable all the table inserters during runtime
+		ease = function() screen_error('cannot be run after beat 0', 1, 'ease') end
+		add = function() screen_error('cannot be run after beat 0', 1, 'add') end
+		func = function() screen_error('cannot be run after beat 0', 1, 'func') end
+		set = function() screen_error('cannot be run after beat 0', 1, 'set') end
+		get = function() screen_error('cannot be run after beat 0', 1, 'get') end
+		setdefault = function() screen_error('cannot be run after beat 0', 1, 'setdefault') end
+		reset = function() screen_error('cannot be run after beat 0', 1, 'reset') end
+		node = function() screen_error('cannot be run after beat 0', 1, 'node') end
+		definemod = function() screen_error('cannot be run after beat 0', 1, 'definemod') end
+		aux = function() screen_error('cannot be run after beat 0', 1, 'aux') end
+		alias = function() screen_error('cannot be run after beat 0', 1, 'alias') end
+
 		self:luaeffect('Update')
 	end
 

--- a/template/template.xml
+++ b/template/template.xml
@@ -197,7 +197,7 @@
 			screen_error('len / end missing', depth, name)
 			return ease
 		end
-		if type(self[3]) ~= 'function' then
+		if type(self[3]) ~= 'function' and (not getmetatable(self[3]) or not getmetatable(self[3]).__call) then
 			screen_error('invalid ease function', depth, name)
 			return ease
 		end

--- a/template/template.xml
+++ b/template/template.xml
@@ -293,6 +293,9 @@
 		self[3] = self[3] or instant
 		self.reset = true
 		self.exclude = self.exclude or {}
+		if type(self.exclude) == 'string' then
+			self.exclude == {self.exclude}
+		end
 		for _, v in ipairs(self.exclude) do
 			self.exclude[v] = true
 		end
@@ -311,7 +314,7 @@
 		end
 		
 		if self.mode or self.m then
-			if type(self[2]) == number then
+			if type(self[2]) == 'number' then
 				self[2] = self[2] - self[1]
 			end
 			if type(self.persist) == 'number' then
@@ -801,7 +804,7 @@
 		apply_modifiers = function(str, pn)
 			if debug_print_applymodifier_input == true or debug_print_applymodifier_input < beat then
 				print('PLAYER ' .. pn .. ': ' .. str)
-				if debug_print_mod_targets ~= true then
+				if debug_print_applymodifier_input ~= true then
 					apply_modifiers = old_apply_modifiers
 				end
 			end
@@ -952,7 +955,7 @@
 						local outputs = {}
 						local i = 0
 						for k, v in pairs(targets[pn]) do
-							if v ~= 0 then
+							if v ~= default_mods[k] then
 								i = i + 1
 								outputs[i] = tostring(k) .. ': ' .. tostring(v)
 							end

--- a/template/template.xml
+++ b/template/template.xml
@@ -790,8 +790,7 @@
 		return x * x * y < x * y * y
 	end)
 	
-	GAMESTATE:ApplyModifiers('clearall,*0 0x,*-1 overhead')
-	-- default eases
+	GAMESTATE:ApplyModifiers('clearall,*-1 overhead')
 	
 	local function apply_modifiers(str, pn)
 		GAMESTATE:ApplyModifiers(str, pn)

--- a/template/template.xml
+++ b/template/template.xml
@@ -1,11 +1,11 @@
 <Template Condition = "(function() --template.xml
-	
+
 	xero()
-	
+
 	max_pn = 8 -- default: `8`
 	local debug_print_applymodifier_input = false -- default: `false`
 	local debug_print_mod_targets = false -- default: `false`
-	
+
 	function copy(src)
 		local dest = {}
 		for k, v in pairs(src) do
@@ -13,7 +13,7 @@
 		end
 		return dest
 	end
-	
+
 	function clear(t)
 		for k, v in pairs(t) do
 			t[k] = nil
@@ -39,24 +39,24 @@
 	math = copy(math)
 	table = copy(table)
 	string = copy(string)
-	
+
 	dw = DISPLAY:GetDisplayWidth()
 	dh = DISPLAY:GetDisplayHeight()
-	
+
 	scx = SCREEN_CENTER_X
 	scy = SCREEN_CENTER_Y
 	sw = SCREEN_WIDTH
 	sh = SCREEN_HEIGHT
 	e = 'end'
 	plr = {1, 2}
-	
+
 	function sprite(self)
 		self:basezoomx(sw / dw)
 		self:basezoomy(-sh / dh)
 		self:x(scx)
 		self:y(scy)
 	end
-	
+
 	function aft(self)
 		self:SetWidth(dw)
 		self:SetHeight(dh)
@@ -66,38 +66,38 @@
 		self:EnablePreserveTexture(true)
 		self:Create()
 	end
-	
+
 	function aftsprite(aft, sprite)
 		sprite:SetTexture(aft:GetTexture())
 	end
-	
+
 	function setupJudgeProxy(proxy, target, pn)
 		proxy:SetTarget(target)
 		proxy:xy(scx * (pn-.5), scy)
 		target:hidden(1)
 		target:sleep(9e9)
 	end
-	
+
 	function screen_error(output, depth, name)
 		local depth = 3 + (type(depth) == 'number' and depth or 0)
 		local _, err = pcall(error, type(name) == 'string' and (name .. ':' .. output) or output, depth)
 		SCREENMAN:SystemMessage(err)
 	end
-	
+
 	local function push(self, obj)
 		self.n = self.n + 1
 		self[self.n] = obj
 	end
-	
+
 	local default_plr = {1, 2}
-	
+
 	function get_plr()
 		return rawget(xero, 'plr') or default_plr
 	end
-	
+
 	-- mod aliases, or ease vars
 	local aliases = {}
-	
+
 	-- alias a mod
 	function alias(self, depth, name)
 		local depth = 1 + (type(depth) == 'number' and depth or 0)
@@ -119,22 +119,22 @@
 		aliases[a] = b
 		return alias
 	end
-	
+
 	function normalize_mod(name)
 		name = string.lower(name)
 		return aliases[name] or name
 	end
-	
+
 	-- eases are loaded after the template, so this needs to be declared early
 	local function instant()
 		return 1
 	end
-	
+
 	local touched_mods = {}
 	for pn = 1, max_pn do
 		touched_mods[pn] = {}
 	end
-	
+
 	-- the table of default mod values
 	local default_mods = setmetatable({}, {
 		__index = function(self, i)
@@ -143,7 +143,7 @@
 		end
 	})
 	local modtable_mt = {__index = default_mods}
-	
+
 	function setdefault(self, depth, name)
 		local depth = 1 + (type(depth) == 'number' and depth or 0)
 		local name = name or 'setdefault'
@@ -167,21 +167,21 @@
 		end
 		return setdefault
 	end
-	
+
 	-- the previously set value of a mod
 	local prev_mods = {}
 	for pn = 1, max_pn do
 		prev_mods[pn] = setmetatable({}, modtable_mt)
 	end
-	
+
 	-- get the previously set value of a mod
 	function get(modname, pn)
 		return prev_mods[pn or 1][modname]
 	end
-	
+
 	-- the table of eases/add/set
 	local eases = {n = 0}
-	
+
 	function ease(self, depth, name)
 		local depth = 1 + (type(depth) == 'number' and depth or 0)
 		local name = name or 'ease'
@@ -260,7 +260,7 @@
 		end
 		return ease
 	end
-	
+
 	function add(self, depth, name)
 		local depth = 1 + (type(depth) == 'number' and depth or 0)
 		local name = name or 'add'
@@ -268,7 +268,7 @@
 		ease(self, depth, name)
 		return add
 	end
-	
+
 	function set(self, depth, name)
 		local depth = 1 + (type(depth) == 'number' and depth or 0)
 		local name = name or 'set'
@@ -301,10 +301,10 @@
 		ease(self, depth, name)
 		return reset
 	end
-	
+
 	-- the table of scheduled functions and perframes
 	local funcs = {n = 0}
-	
+
 	function func(self, depth, name)
 		local name = name or 'func'
 		local depth = 1 + (type(depth) == 'number' and depth or 0)
@@ -312,7 +312,7 @@
 			screen_error('curly braces expected', depth, name)
 			return func
 		end
-		
+
 		if self.mode or self.m then
 			if type(self[2]) == 'number' then
 				self[2] = self[2] - self[1]
@@ -321,7 +321,7 @@
 				self.persist = self.persist - self[1]
 			end
 		end
-		
+
 		local can_use_poptions = false
 		local a, b, c, d, e, f = self[1], self[2], self[3], self[4], self[5], self[6]
 		-- function ease, type 3
@@ -385,10 +385,10 @@
 		end
 		return func
 	end
-	
+
 	-- auxilliary variables
 	local auxes = {}
-	
+
 	function aux(self, depth, name)
 		local depth = 1 + (type(depth) == 'number' and depth or 0)
 		local name = name or 'aux'
@@ -404,11 +404,11 @@
 		end
 		return aux
 	end
-	
+
 	-- the table of nodes
 	local nodes = {n = 0}
 	local node_start
-	
+
 	function node(self, depth, name)
 		local depth = 1 + (type(depth) == 'number' and depth or 0)
 		local name = name or 'node'
@@ -440,7 +440,7 @@
 		push(nodes, result)
 		return node
 	end
-	
+
 	-- used to create your own mods.
 	-- calls aux and node on the provided arguments
 	function definemod(self, depth, name)
@@ -455,11 +455,11 @@
 		node(self, depth, name)
 		return definemod
 	end
-	
+
 	local mods = {}
 	mod_buffer = stringbuilder()
-	
 	function compile_nodes()
+
 		local terminators = {}
 		for _, nd in ipairs(nodes) do
 			for _, mod in ipairs(nd[2]) do
@@ -524,14 +524,14 @@
 					table.insert(last[v], nd)
 				end
 			end
-			
+
 			local function escapestr(s)
 				return '\'' .. string.gsub(s, '[\\\']', '\\%1') .. '\''
 			end
 			local function list(code, i, sep)
 				if i ~= 1 then code(sep) end
 			end
-			
+
 			local code = stringbuilder()
 			local function emit_inputs()
 				for i, mod in ipairs(inputs) do
@@ -564,7 +564,7 @@
 					code
 				'end\n'
 			'end\n'
-			
+
 			local compiled = assert(loadstring(code:build()))()
 			nd[6] = compiled(outputs, parents, mods, fn)
 			if not terminator then
@@ -578,7 +578,7 @@
 		end
 		node_start = start
 	end
-	
+
 	-- replaces aliases with their respective mods
 	local function resolve_aliases()
 		-- ease
@@ -605,7 +605,7 @@
 			default_mods[normalize_mod(mod)] = percent
 		end
 	end
-	
+
 	-- takes every actor with a Name= and places it in the xero table
 	local function scan_named_actors()
 		local mt = {}
@@ -635,14 +635,14 @@
 				end
 			end
 		end
-		
+
 		code'return function(list, actors)\n'
 			sweep(foreground, true)
 		code'end'
-		
+
 		local load_actors = xero(assert(loadstring(code:build())))()
 		load_actors(list, actors)
-		
+
 		local function clear_metatables(tab)
 			setmetatable(tab, nil)
 			for _, obj in pairs(tab) do
@@ -652,20 +652,20 @@
 			end
 		end
 		clear_metatables(actors)
-		
+
 		for name, actor in pairs(actors) do
 			xero[name] = actor
 		end
-		
+
 	end
-	
+
 	function on_command(self)
 		scan_named_actors()
 		self:queuecommand('BeginUpdate')
 	end
-	
+
 	function begin_update_command(self)
-		
+
 		for _, element in ipairs {
 			'Overlay', 'Underlay',
 			'ScoreP1', 'ScoreP2',
@@ -674,16 +674,16 @@
 			local child = SCREENMAN(element)
 			if child then child:hidden(1) end
 		end
-		
+
 		P = {}
 		for pn = 1, max_pn do
 			local player = SCREENMAN('PlayerP' .. pn)
 			xero['P' .. pn] = player
 			P[pn] = player
 		end
-		
+
 		foreground:playcommand('Load')
-		
+
 		stable_sort(eases, function(a, b) return a[1] < b[1] end)
 		stable_sort(funcs, function(a, b)
 			if a[1] == b[1] then
@@ -699,10 +699,10 @@
 		end)
 		resolve_aliases()
 		compile_nodes()
-		
+
 		self:luaeffect('Update')
 	end
-	
+
 	-- zoom
 	aux 'zoom'
 	node {
@@ -715,7 +715,7 @@
 		defer = true,
 	}
 	setdefault {100, 'zoom', 100, 'zoomx', 100, 'zoomy', 100, 'zoomz'}
-	
+
 	-- movex
 	for _, a in ipairs {'x', 'y', 'z'} do
 		aux {'move' .. a}
@@ -729,7 +729,7 @@
 			defer = true,
 		}
 	end
-	
+
 	-- xmod
 	aux 'xmod' 'cmod'
 	node {
@@ -744,12 +744,12 @@
 		defer = true,
 	}
 	setdefault {1, 'xmod'}
-	
 	local targets = {}
+
 	for pn = 1, max_pn do
 		targets[pn] = setmetatable({}, modtable_mt)
 	end
-	
+
 	local mods_mt = {}
 	for pn = 1, max_pn do
 		mods_mt[pn] = {__index = targets[pn]}
@@ -759,9 +759,9 @@
 	for pn = 1, max_pn do
 		mods[pn] = setmetatable({}, mods_mt[pn])
 	end
-	
+
 	local last_seen_awake = {}
-	
+
 	local poptions = {}
 	local poptions_mt = {}
 	local poptions_logging_target
@@ -783,22 +783,22 @@
 		poptions_mt[pn] = mt
 		poptions[pn] = setmetatable({}, mt)
 	end
-	
+
 	local eases_index = 1
 	local funcs_index = 1
-	
+
 	local active_eases = {n = 0}
 	local active_funcs = perframe_data_structure(function(a, b)
 		local x, y = a.priority, b.priority
 		return x * x * y < x * y * y
 	end)
-	
+
 	GAMESTATE:ApplyModifiers('clearall,*-1 overhead')
-	
+
 	local function apply_modifiers(str, pn)
 		GAMESTATE:ApplyModifiers(str, pn)
 	end
-	
+
 	if debug_print_applymodifier_input then
 		local old_apply_modifiers = apply_modifiers
 		apply_modifiers = function(str, pn)
@@ -811,7 +811,7 @@
 			old_apply_modifiers(str, pn)
 		end
 	end
-	
+
 	local seen = 1
 	local active_nodes = {}
 	local active_terminators = {}
@@ -834,14 +834,14 @@
 			end
 		end
 	end
-	
+
 	local oldbeat = 0
 	function update_command(self)
-		
+
 		local beat = GAMESTATE:GetSongBeat()
 		if beat == oldbeat then return end
 		oldbeat = beat
-		
+
 		while eases_index <= eases.n and eases[eases_index][1] < beat do
 			local e = eases[eases_index]
 			local plr = e.plr
@@ -869,7 +869,7 @@
 			push(active_eases, e)
 			eases_index = eases_index + 1
 		end
-		
+
 		local active_eases_index = 1
 		while active_eases_index <= active_eases.n do
 			local e = active_eases[active_eases_index]
@@ -891,7 +891,7 @@
 				active_eases.n = active_eases.n - 1
 			end
 		end
-		
+
 		while funcs_index <= funcs.n and funcs[funcs_index][1] < beat do
 			local e = funcs[funcs_index]
 			if not e[2] then
@@ -901,7 +901,7 @@
 			end
 			funcs_index = funcs_index + 1
 		end
-		
+
 		while true do
 			local e = active_funcs:next()
 			if not e then break end
@@ -919,7 +919,7 @@
 				active_funcs:remove()
 			end
 		end
-		
+
 		for pn = 1, max_pn do
 			if P[pn] and P[pn]:IsAwake() then
 				if not last_seen_awake[pn] then
@@ -960,7 +960,7 @@
 				end
 			end
 		end
-		
+
 		if debug_print_mod_targets then
 			if debug_print_mod_targets == true or debug_print_mod_targets < beat then
 				for pn = 1, max_pn do

--- a/template/template.xml
+++ b/template/template.xml
@@ -468,9 +468,38 @@
 	end
 
 	local mods = {}
+	local targets = {}
 	mod_buffer = stringbuilder()
-	function compile_nodes()
 
+
+	function touch_mod(mod, pn)
+		-- run metatables
+		if pn then
+			mods[pn][mod] = mods[pn][mod]
+		else
+			for pn = 1, max_pn do
+				touch_mod(mod, pn)
+			end
+		end
+	end
+
+	function touch_all_mods()
+		for mod in pairs(default_mods) do
+			touch_mod(mod)
+		end
+		for pn = 1, max_pn do
+			for mod in pairs(targets[pn]) do
+				touch_mod(mod, pn)
+			end
+		end
+	end
+
+	function launchattack(start_time, len, mods, pn)
+		GAMESTATE:LaunchAttack(start_time, len, mods, pn)
+		func{start_time, touch_all_mods}
+	end
+
+	local function compile_nodes()
 		local terminators = {}
 		for _, nd in ipairs(nodes) do
 			for _, mod in ipairs(nd[2]) do
@@ -755,8 +784,9 @@
 		defer = true,
 	}
 	setdefault {1, 'xmod'}
-	local targets = {}
 
+	-- defined earlier
+	local targets = targets
 	for pn = 1, max_pn do
 		targets[pn] = setmetatable({}, modtable_mt)
 	end
@@ -895,7 +925,7 @@
 			else
 				for i = 4, e.n, 2 do
 					local mod = e[i + 1]
-					mods[plr][mod] = mods[plr][mod] + 0
+					touch_mod(mod, plr)
 				end
 				active_eases[active_eases_index] = active_eases[active_eases.n]
 				active_eases[active_eases.n] = nil
@@ -921,10 +951,8 @@
 				e[3](beat, poptions)
 			else
 				if e.mods then
-					for pn = 1, max_pn do
-						for mod, _ in e.mods[pn] do
-							mods[pn][mod] = mods[pn][mod] + 0
-						end
+					for mod, _ in e.mods[pn] do
+						touch_mod(mod)
 					end
 				end
 				active_funcs:remove()
@@ -936,7 +964,7 @@
 				if not last_seen_awake[pn] then
 					last_seen_awake[pn] = true
 					for mod, percent in pairs(touched_mods[pn]) do
-						mods[pn][mod] = mods[pn][mod] + 0
+						touch_mod(mod, pn)
 						touched_mods[pn][mod] = nil
 					end
 				end


### PR DESCRIPTION
Features:
+ New func variation for function eases for when you have a small function
```lua
func{0, 1, inOutExpo, 0, scx, 'P1:x'}
```
+ Aliases are more precise, so you can do complicated things with alias:
```lua
alias
{'movex1', 'movex0'}
{'movex2', 'movex1'}
{'movex3', 'movex2'}
{'movex4', 'movex3'}
```
+ New parameters for eases:
```lua
func {0, 1, outElastic.params(1.5, 0.1), 100, 'invert'}
```
+ New helper functions `touch_mod(mod, pn)` and `touch_all_mods(pn)`
    Now you can run `touch_all_mods(pn)` after setting a noteskin with LaunchAttack to keep the mods on.

Fixes:
* if you ease a player that's asleep, it will have the correct mods when it is set to be awake
* reset and setdefault can now be chained (like, more than one {})
* zoomz now correctly defaults to 100
* grain now defaults to 400
* outExpo now is actually smooth, and doesn't end at 0.998 and then jump to 1.0
* slightly better error message for when definemod or node have wrong argument order (still bad)

Not done yet:
? error messages if you call ease or func mid files (or maybe support for calling ease and func mid file? :eyes::eyes::eyes::eyes:)
? maybe make mirin happy and have a feature to automatically define-mod a thing (not clear how this would work yet, who knows)

Docs needed:
touch_mod
touch_all_mod
How to make a collab / use reset effectively / split up xml
update the func for the string syntax
New eases with params
